### PR TITLE
AMB-221 Disables 'Try this API'

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -10,6 +10,8 @@ jobs:
       - name: Grab ticket name
         if: contains(github.event.pull_request.head.ref, 'amb-') || contains(github.event.pull_request.head.ref, 'AMB-')
         run: echo ::set-env name=TICKET_NAME::$(echo ${{ github.event.pull_request.head.ref }} | grep -i -o 'amb-[0-9]\+' | tr '[:lower:]' '[:upper:]')
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Comment on PR
         if: contains(github.event.pull_request.head.ref, 'amb-') || contains(github.event.pull_request.head.ref, 'AMB-')

--- a/specification/mesh-api.yaml
+++ b/specification/mesh-api.yaml
@@ -246,6 +246,9 @@ servers:
     description: Production
   - url: 'https://mesh.spineservices.nhs.uk'
     description: Production
+x-spec-publication:
+  try-this-api:
+    disabled: true
 paths:
   '/messageexchange/{mailboxID}':
     get:


### PR DESCRIPTION
## Summary
This **routine change** adds custom [Specification Extension](https://spec.openapis.org/oas/v3.0.3#specification-extensions) property `x-spec-publication.try-this-api.disabled` which allows toggling visibility of the 'Try this API' button in the specification's page on NHSD website.

Setting this property to true removes the 'Try this API' button; setting it to `false` or removing it altogether restores the button.

Actually implemented as [ADZ-460](https://nhsd-jira.digital.nhs.uk/browse/ADZ-460) (see for more details and the link to documentation) but originally raised as [AMB-221](https://nhsd-jira.digital.nhs.uk/browse/AMB-221).


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [x] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
