### PR TITLE
APM-2018 Disable monitoring for MESH API

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -5,16 +5,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check ticket name conforms to requirements
-        run: echo ${{ github.event.pull_request.head.ref }} | grep -i -E -q "(amb-[0-9]+)|(spii-[0-9]+)|(apmspii-[0-9]+)|(dependabot\/)"
+        run: echo ${{ github.event.pull_request.head.ref }} | grep -i -E -q "(apm-[0-9]+)|(amb-[0-9]+)|(spii-[0-9]+)|(apmspii-[0-9]+)|(dependabot\/)"
 
       - name: Grab ticket name
-        if: contains(github.event.pull_request.head.ref, 'amb-') || contains(github.event.pull_request.head.ref, 'AMB-') || contains(github.event.pull_request.head.ref, 'spii-') || contains(github.event.pull_request.head.ref, 'SPII-') || contains(github.event.pull_request.head.ref, 'apmspii-') || contains(github.event.pull_request.head.ref, 'APMSPII-')
+        if: contains(github.event.pull_request.head.ref, 'apm-') || contains(github.event.pull_request.head.ref, 'APM-') || contains(github.event.pull_request.head.ref, 'amb-') || contains(github.event.pull_request.head.ref, 'AMB-') || contains(github.event.pull_request.head.ref, 'spii-') || contains(github.event.pull_request.head.ref, 'SPII-') || contains(github.event.pull_request.head.ref, 'apmspii-') || contains(github.event.pull_request.head.ref, 'APMSPII-')
         run: echo ::set-env name=TICKET_NAME::$(echo ${{ github.event.pull_request.head.ref }} | grep -i -o '\(amb-[0-9]\+\)\|\(spii-[0-9]\+\)|\(apmspii-[0-9]\+\)' | tr '[:lower:]' '[:upper:]')
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Comment on PR
-        if: contains(github.event.pull_request.head.ref, 'amb-') || contains(github.event.pull_request.head.ref, 'AMB-') || contains(github.event.pull_request.head.ref, 'spii-') || contains(github.event.pull_request.head.ref, 'SPII-') || contains(github.event.pull_request.head.ref, 'apmspii-') || contains(github.event.pull_request.head.ref, 'APMSPII-')
+        if: contains(github.event.pull_request.head.ref, 'apm-') || contains(github.event.pull_request.head.ref, 'APM-') || contains(github.event.pull_request.head.ref, 'amb-') || contains(github.event.pull_request.head.ref, 'AMB-') || contains(github.event.pull_request.head.ref, 'spii-') || contains(github.event.pull_request.head.ref, 'SPII-') || contains(github.event.pull_request.head.ref, 'apmspii-') || contains(github.event.pull_request.head.ref, 'APMSPII-')
         uses: unsplash/comment-on-pr@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -35,6 +35,7 @@ extends:
     product_description: ${{ variables.product_description }}
     spec_file: ${{ variables.spec_file }}
     enable_monitoring: false
+    enable_status_monitoring: false
     prod_requires_approval: false
     apigee_deployments:
       - environment: internal-dev


### PR DESCRIPTION
Mesh API does not deploy a proxy so it doesn't need monitoring.